### PR TITLE
Set min-width of body to 650px to resolve beer list grid rendering issue

### DIFF
--- a/NamaBeer.Client/Content/style.css
+++ b/NamaBeer.Client/Content/style.css
@@ -5,3 +5,7 @@
 .btn-confirm {
 	width: 80px;
 }
+
+body {
+	min-width: 650px;
+}


### PR DESCRIPTION
This will prevent the beer list grid from being reduced below 650px and keeps the menu button vertically in-line with the grids edge.

This resolves issue #3.
